### PR TITLE
Fix /pages/admin/list-images

### DIFF
--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -195,41 +195,35 @@ function DeleteModal({
   }
 
   return (
-    <div className="fixed inset-0 h-full w-full bg-black/90">
-      <div className="fixed top-1/2 left-4 sm:left-1/2">
-        <button
-          className="absolute -top-16 right-0 text-white hover:border"
-          onClick={() => closeModal()}
-        >
-          <X className="size-8" />
-        </button>
-        <div>
-          <form
-            className="flex flex-col"
-            onSubmit={(e) => void handleSubmit(e)}
-          >
-            <p className="text-white">
-              Delete image{' '}
-              <span className="text-lg font-bold">{imageName}</span>?
-            </p>
-            <div className="mt-4 flex w-full justify-center">
-              <button
-                className="mr-4 w-20 rounded-lg border text-white hover:bg-gray-500"
-                type="button"
-                onClick={() => closeModal()}
-              >
-                Cancel
-              </button>
-              <button
-                className="w-20 rounded-lg border text-white hover:bg-gray-500"
-                type="submit"
-              >
-                Submit
-              </button>
-            </div>
-          </form>
-        </div>
+    <Modal closeModal={() => closeModal()} firstDivClassName="opacity-90">
+      <button
+        className="absolute -top-16 right-0 text-white hover:border"
+        onClick={() => closeModal()}
+      >
+        <X className="size-8" />
+      </button>
+      <div>
+        <form className="flex flex-col" onSubmit={(e) => void handleSubmit(e)}>
+          <p className="text-white">
+            Delete image <span className="text-lg font-bold">{imageName}</span>?
+          </p>
+          <div className="mt-4 flex w-full justify-center">
+            <button
+              className="mr-4 w-20 rounded-lg border text-white hover:bg-gray-500"
+              type="button"
+              onClick={() => closeModal()}
+            >
+              Cancel
+            </button>
+            <button
+              className="w-20 rounded-lg border text-white hover:bg-gray-500"
+              type="submit"
+            >
+              Submit
+            </button>
+          </div>
+        </form>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { FormEvent, useEffect, useState } from 'react';
 import { Input } from '~/components/Input';
 import { Main } from '~/components/Main';
+import { Modal } from '~/components/Modal';
 import { NavBarAdmin } from '~/components/NavBarAdmin';
 import { QueryAndMutationKeys } from '~/shared/types';
 import { getServerSidePropsAdminOnly as getServerSideProps } from '~/utils/getServerSideProps';
@@ -134,44 +135,39 @@ function EditModal({
   }
 
   return (
-    <div className="fixed inset-0 h-full w-full bg-black/90">
-      <div className="fixed top-1/2 left-4 sm:left-1/2">
-        <button
-          className="absolute -top-4 right-0 text-white hover:border"
-          onClick={() => closeModal()}
-        >
-          <X className="size-8" />
-        </button>
-        <div>
-          <form
-            className="flex flex-col"
-            onSubmit={(e) => void handleSubmit(e)}
-          >
-            <label className="text-white">Image Name:</label>
-            <Input
-              className="w-72"
-              value={newImageName}
-              onChange={(e) => setNewImageName(e.target.value)}
-            />
-            <div className="mt-4 flex w-full justify-center">
-              <button
-                className="mr-4 w-20 rounded-lg border text-white hover:bg-gray-500"
-                type="button"
-                onClick={() => closeModal()}
-              >
-                Cancel
-              </button>
-              <button
-                className="w-20 rounded-lg border text-white hover:bg-gray-500"
-                type="submit"
-              >
-                Submit
-              </button>
-            </div>
-          </form>
-        </div>
+    <Modal closeModal={() => closeModal()} firstDivClassName="opacity-90">
+      <button
+        className="absolute -top-4 right-0 text-white hover:border"
+        onClick={() => closeModal()}
+      >
+        <X className="size-8" />
+      </button>
+      <div>
+        <form className="flex flex-col" onSubmit={(e) => void handleSubmit(e)}>
+          <label className="text-white">Image Name:</label>
+          <Input
+            className="w-72"
+            value={newImageName}
+            onChange={(e) => setNewImageName(e.target.value)}
+          />
+          <div className="mt-4 flex w-full justify-center">
+            <button
+              className="mr-4 w-20 rounded-lg border text-white hover:bg-gray-500"
+              type="button"
+              onClick={() => closeModal()}
+            >
+              Cancel
+            </button>
+            <button
+              className="w-20 rounded-lg border text-white hover:bg-gray-500"
+              type="submit"
+            >
+              Submit
+            </button>
+          </div>
+        </form>
       </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { EditIcon, Trash2, X } from 'lucide-react';
 import Image from 'next/image';
@@ -15,16 +16,24 @@ export default function ListImages() {
   const [editModalData, setEditModalData] = useState('');
   const [deleteModalData, setDeleteModalData] = useState('');
 
+  const { data: fetchedImages, refetch } = useQuery({
+    queryKey: ['ListImages'],
+    queryFn: async () => {
+      return (await axios.get('/api/admin/list-images')).data as string[];
+    },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: false,
+  });
+
   useEffect(() => {
     async function runThis() {
-      const fetchedImages = (await (
-        await axios.get('/api/admin/list-images')
-      ).data) as string[];
-      setImages(fetchedImages);
+      await refetch();
+      setImages(fetchedImages || []);
     }
 
     void runThis();
-  }, []);
+  }, [fetchedImages, refetch]);
 
   return (
     <Main>

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -8,6 +8,7 @@ import { Main } from '~/components/Main';
 import { Modal } from '~/components/Modal';
 import { NavBarAdmin } from '~/components/NavBarAdmin';
 import { QueryAndMutationKeys } from '~/shared/types';
+import { BASE_IMAGE_URL } from '~/utils/constants';
 import { getServerSidePropsAdminOnly as getServerSideProps } from '~/utils/getServerSideProps';
 
 /* ADMINS ONLY */
@@ -17,6 +18,7 @@ export default function ListImages() {
   const [images, setImages] = useState<string[]>([]);
   const [editModalData, setEditModalData] = useState('');
   const [deleteModalData, setDeleteModalData] = useState('');
+  const [zoomedImageModalData, setZoomedImageModalData] = useState('');
 
   const queryClient = useQueryClient();
 
@@ -52,14 +54,20 @@ export default function ListImages() {
               key={`imageDiv_${_index}`}
               className="flex w-full flex-col items-center border sm:w-72"
             >
-              <Image
-                priority={true}
-                alt="image"
-                src={`/images/products/${_image}`}
-                width={1920}
-                height={1080}
-                className="size-48 object-contain"
-              />
+              <button
+                onClick={() =>
+                  setZoomedImageModalData(`/images/products/${_image}`)
+                }
+              >
+                <Image
+                  priority={true}
+                  alt="image"
+                  src={`/images/products/${_image}`}
+                  width={1920}
+                  height={1080}
+                  className="size-48 object-contain"
+                />
+              </button>
               <p className="wrap-anywhere">{_image}</p>
               <div>
                 <button
@@ -92,6 +100,12 @@ export default function ListImages() {
           closeModal={() => setDeleteModalData('')}
           imageName={deleteModalData}
           queryClient={queryClient}
+        />
+      )}
+      {zoomedImageModalData && (
+        <ZoomImageModal
+          closeModal={() => setZoomedImageModalData('')}
+          imageHref={zoomedImageModalData}
         />
       )}
     </Main>
@@ -224,6 +238,34 @@ function DeleteModal({
           </div>
         </form>
       </div>
+    </Modal>
+  );
+}
+
+function ZoomImageModal({
+  closeModal,
+  imageHref,
+}: {
+  closeModal: () => void;
+  imageHref: string;
+}) {
+  return (
+    <Modal closeModal={() => closeModal()}>
+      <div className="absolute -top-24 -right-7 z-10">
+        <button type="button" onClick={() => closeModal()}>
+          <X className="size-24 text-white" />
+        </button>
+      </div>
+      <a href={imageHref || BASE_IMAGE_URL} target="_blank" className="z-0">
+        <Image
+          priority={true}
+          alt="SSD"
+          src={imageHref || BASE_IMAGE_URL}
+          blurDataURL="/images/products/image_base.png"
+          width={1920}
+          height={1080}
+        />
+      </a>
     </Modal>
   );
 }

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -90,6 +90,7 @@ export default function ListImages() {
         <DeleteModal
           closeModal={() => setDeleteModalData('')}
           imageName={deleteModalData}
+          queryClient={queryClient}
         />
       )}
     </Main>
@@ -177,15 +178,20 @@ function EditModal({
 function DeleteModal({
   imageName,
   closeModal,
+  queryClient,
 }: {
   imageName: string;
   closeModal: () => void;
+  queryClient: QueryClient;
 }) {
   async function handleSubmit(e: FormEvent<HTMLElement>) {
     e.preventDefault();
     try {
       console.log('Submit');
       await axios.delete('/api/admin/list-images', { data: imageName });
+      await queryClient.invalidateQueries({
+        queryKey: QueryAndMutationKeys.ListImages,
+      });
       closeModal();
     } catch (e) {
       console.error(e);

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -249,6 +249,7 @@ function ZoomImageModal({
   closeModal: () => void;
   imageHref: string;
 }) {
+  /* Starting at row 260 is kinda of a workaround. Check if it really works */
   return (
     <Modal closeModal={() => closeModal()}>
       <div className="absolute -top-24 -right-7 z-10">
@@ -256,16 +257,19 @@ function ZoomImageModal({
           <X className="size-24 text-white" />
         </button>
       </div>
-      <a href={imageHref || BASE_IMAGE_URL} target="_blank" className="z-0">
-        <Image
-          priority={true}
-          alt="SSD"
-          src={imageHref || BASE_IMAGE_URL}
-          blurDataURL="/images/products/image_base.png"
-          width={1920}
-          height={1080}
-        />
-      </a>
+      <div className="overflow-auto sm:h-[52rem]">
+        <a href={imageHref || BASE_IMAGE_URL} target="_blank" className="">
+          <Image
+            priority={true}
+            alt="SSD"
+            src={imageHref || BASE_IMAGE_URL}
+            blurDataURL="/images/products/image_base.png"
+            className="object-contain"
+            width={1920}
+            height={1080}
+          />
+        </a>
+      </div>
     </Modal>
   );
 }

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -46,7 +46,7 @@ export default function ListImages() {
           return (
             <div
               key={`imageDiv_${_index}`}
-              className="flex w-96 flex-col items-center border"
+              className="flex w-full flex-col items-center border sm:w-72"
             >
               <Image
                 priority={true}

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -15,14 +15,13 @@ import { getServerSidePropsAdminOnly as getServerSideProps } from '~/utils/getSe
 export { getServerSideProps };
 
 export default function ListImages() {
-  const [images, setImages] = useState<string[]>([]);
   const [editModalData, setEditModalData] = useState('');
   const [deleteModalData, setDeleteModalData] = useState('');
   const [zoomedImageModalData, setZoomedImageModalData] = useState('');
 
   const queryClient = useQueryClient();
 
-  const { data: fetchedImages, refetch } = useQuery({
+  const { data: images } = useQuery({
     queryKey: QueryAndMutationKeys.ListImages,
     queryFn: async () => {
       return (await axios.get('/api/admin/list-images')).data as string[];
@@ -32,15 +31,6 @@ export default function ListImages() {
     retry: false,
   });
 
-  useEffect(() => {
-    async function runThis() {
-      await refetch();
-      setImages(fetchedImages || []);
-    }
-
-    void runThis();
-  }, [fetchedImages, refetch]);
-
   return (
     <Main>
       <NavBarAdmin />
@@ -48,7 +38,7 @@ export default function ListImages() {
         List Images
       </p>
       <div className="mt-5 flex w-full flex-wrap">
-        {images.map((_image, _index) => {
+        {images?.map((_image, _index) => {
           return (
             <div
               key={`imageDiv_${_index}`}
@@ -91,7 +81,7 @@ export default function ListImages() {
         <EditModal
           closeModal={() => setEditModalData('')}
           imageName={editModalData}
-          allImages={images}
+          allImages={images || []}
           queryClient={queryClient}
         />
       )}
@@ -249,7 +239,7 @@ function ZoomImageModal({
   closeModal: () => void;
   imageHref: string;
 }) {
-  /* Starting at row 260 is kinda of a workaround. Check if it really works */
+  /* Starting at row 260 is kinda of a workaround. Check if it really works   */
   return (
     <Modal closeModal={() => closeModal()}>
       <div className="absolute -top-24 -right-7 z-10">

--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -45,7 +45,7 @@ export default function ListImages() {
                 src={`/images/products/${_image}`}
                 width={1920}
                 height={1080}
-                className="size-48"
+                className="size-48 object-contain"
               />
               <p className="wrap-anywhere">{_image}</p>
               <div>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -96,6 +96,7 @@ export const QueryAndMutationKeys = {
   Products: ['products'],
   Product: ['product'],
   Images: ['images'],
+  ListImages: ['ListImages'],
   UpdateCartTotalAmount: ['updateCartTotalAmount'],
   Login: ['login'],
   Register: ['register'],


### PR DESCRIPTION
Fix /pages/admin/list-images. When an image is renamed or deleted, the images don't get updated


Fix at least following things:

- [x] Refresh images when renaming or deletion happens
- [x] Add a Tanstack query to the image deletion request
- [x] Add a possibility to open images larger & as a link into the image itself. This has been done in /product/[id]
- [x] Centerize Edit and Delete Modals


Closes issue #14