### PR TITLE
Add features to /pages/admin/upload-images

### DIFF
--- a/pages/admin/list-images.tsx
+++ b/pages/admin/list-images.tsx
@@ -2,7 +2,7 @@ import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { EditIcon, Trash2, X } from 'lucide-react';
 import Image from 'next/image';
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { Input } from '~/components/Input';
 import { Main } from '~/components/Main';
 import { Modal } from '~/components/Modal';

--- a/pages/admin/upload-images.tsx
+++ b/pages/admin/upload-images.tsx
@@ -73,7 +73,7 @@ export default function AdminIndex() {
       <div className="mt-5 flex w-full justify-center">
         <form
           className="flex flex-col items-center"
-          onSubmit={(e) => void (async () => await handleSubmit(e))}
+          onSubmit={(e) => void handleSubmit(e)}
         >
           <label htmlFor="filename">Choose an image you want to upload</label>
           <input

--- a/pages/admin/upload-images.tsx
+++ b/pages/admin/upload-images.tsx
@@ -25,7 +25,7 @@ export default function AdminIndex() {
     mutationKey: QueryAndMutationKeys.UploadImage,
     mutationFn: async () =>
       await axios.post('/api/admin/upload', inputRef.current?.files),
-    onSuccess: async () => {
+    onSuccess: () => {
       try {
         queryClient.clear();
         toast('Image uploaded succesfully!');
@@ -73,7 +73,7 @@ export default function AdminIndex() {
       <div className="mt-5 flex w-full justify-center">
         <form
           className="flex flex-col items-center"
-          onSubmit={(e) => handleSubmit(e)}
+          onSubmit={(e) => void (async () => await handleSubmit(e))}
         >
           <label htmlFor="filename">Choose an image you want to upload</label>
           <input

--- a/pages/api/admin/upload/index.ts
+++ b/pages/api/admin/upload/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import formidable, { errors as FormidableErrors } from 'formidable';
+import formidable from 'formidable';
 import fs from 'fs';
 import { checkIsAdminFromValidateRequest } from '~/backend/utils';
 import { validateRequest } from '~/backend/auth/auth';
@@ -81,6 +81,8 @@ export default async function UploadHandler(
       form.parse(req, (e, _, files) => {
         if (e) {
           // Reference: https://github.com/node-formidable/formidable/issues/972#issuecomment-2442784495
+          // CHECK THIS, could Zod be added here?
+          /* eslint-disable */
           if (typeof e === 'object' && 'code' in e && 'httpCode' in e) {
             if (
               e.code === FormidableErrorCodes.biggerThanMaxFileSize ||
@@ -90,6 +92,7 @@ export default async function UploadHandler(
               return resolve();
             }
           }
+          /* eslint-enable */
           console.error('Error parsing form:', e);
           res.status(500).json({ error: 'File upload failed.' });
           resolve();

--- a/pages/api/admin/upload/index.ts
+++ b/pages/api/admin/upload/index.ts
@@ -99,7 +99,6 @@ export default async function UploadHandler(
         }
 
         const uploadedFile = Object.keys(files).length > 0;
-        console.log(uploadedFile);
         if (!uploadedFile) {
           if (UPLOAD_ERROR) {
             res.status(400).send(UPLOAD_ERROR);

--- a/pages/api/admin/upload/index.ts
+++ b/pages/api/admin/upload/index.ts
@@ -1,9 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import formidable from 'formidable';
+import formidable, { errors as FormidableErrors } from 'formidable';
 import fs from 'fs';
 import { checkIsAdminFromValidateRequest } from '~/backend/utils';
 import { validateRequest } from '~/backend/auth/auth';
 import { HttpError } from '~/backend/HttpError';
+import { handleError } from '~/backend/handleError';
+import { FormidableErrorCodes } from '~/shared/types';
 
 export const config = {
   api: {
@@ -27,6 +29,11 @@ export default async function UploadHandler(
       throw new HttpError("You don't have privileges to do that", 400);
     }
 
+    let UPLOAD_ERROR:
+      | 'Invalid file type'
+      | 'File exists in database already'
+      | '';
+
     const form = formidable({
       uploadDir: uploadFolderLocation,
       keepExtensions: true,
@@ -45,6 +52,7 @@ export default async function UploadHandler(
           console.warn(
             `Rejected file: ${originalFilename} with invalid MIME type: ${mimetype}`,
           );
+          UPLOAD_ERROR = 'Invalid file type';
           return false;
         }
 
@@ -55,35 +63,57 @@ export default async function UploadHandler(
 
           // image is existing already, skip adding
           if (access === undefined) {
+            UPLOAD_ERROR = 'File exists in database already';
             return false;
           }
           // eslint-disable-next-line
         } catch (e) {
-          // throws and error if image was not found, we can add the image
+          // throws an error if image was not found, we can add the image
           return true;
         }
 
         return false;
       },
     });
+    // wrap form.parse to the Promise to avoid following warning:
+    // API resolved without sending a response for /api/admin/upload, this may result in stalled requests.
+    await new Promise<void>((resolve) => {
+      form.parse(req, (e, _, files) => {
+        if (e) {
+          // Reference: https://github.com/node-formidable/formidable/issues/972#issuecomment-2442784495
+          if (typeof e === 'object' && 'code' in e && 'httpCode' in e) {
+            if (
+              e.code === FormidableErrorCodes.biggerThanMaxFileSize ||
+              e.code === FormidableErrorCodes.maxTotalFileSize
+            ) {
+              res.status(e.httpCode || 400).send('File was too large');
+              return resolve();
+            }
+          }
+          console.error('Error parsing form:', e);
+          res.status(500).json({ error: 'File upload failed.' });
+          resolve();
+        }
 
-    form.parse(req, (err, _, files) => {
-      if (err) {
-        console.error('Error parsing form:', err);
-        return res.status(500).json({ error: 'File upload failed.' });
-      }
+        const uploadedFile = Object.keys(files).length > 0;
+        console.log(uploadedFile);
+        if (!uploadedFile) {
+          if (UPLOAD_ERROR) {
+            res.status(400).send(UPLOAD_ERROR);
+            return resolve();
+          }
+          res.status(400).json({ error: 'File uploaded was invalid' });
+          return resolve();
+        }
 
-      const uploadedFile = files.myFile;
-
-      if (!uploadedFile) {
-        return res.status(400).json({ error: 'No file uploaded.' });
-      }
-
-      console.log('File uploaded successfully:', uploadedFile);
+        console.log('File uploaded successfully:', uploadedFile);
+        res.status(200).end();
+        resolve();
+      });
     });
-
-    res.status(200).end();
+    //res.status(res.statusCode || 200).send()
   } catch (e) {
     console.error(e);
+    return handleError(res, e);
   }
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -222,3 +222,48 @@ export type KeyboardEventKeys =
   | 'F12'
   | 'Num Lock'
   | 'Scroll Lock';
+
+export const FormidableErrorCodes: Record<
+  | 'missingPlugin'
+  | 'pluginFunction'
+  | 'aborted'
+  | 'noParser'
+  | 'uninitializedParser'
+  | 'filenameNotString'
+  | 'maxFieldsSizeExceeded'
+  | 'maxFieldsExceeded'
+  | 'smallerThanMinFileSize'
+  | 'biggerThanTotalMaxFileSize'
+  | 'noEmptyFiles'
+  | 'missingContentType'
+  | 'malformedMultipart'
+  | 'missingMultipartBoundary'
+  | 'unknownTransferEncoding'
+  | 'maxFilesExceeded'
+  | 'maxTotalFileSize'
+  | 'biggerThanMaxFileSize'
+  | 'pluginFailed'
+  | 'cannotCreateDir',
+  number
+> = {
+  missingPlugin: 1000,
+  pluginFunction: 1001,
+  aborted: 1002,
+  noParser: 1003,
+  uninitializedParser: 1004,
+  filenameNotString: 1005,
+  maxFieldsSizeExceeded: 1006,
+  maxFieldsExceeded: 1007,
+  smallerThanMinFileSize: 1008,
+  maxTotalFileSize: 1009,
+  biggerThanTotalMaxFileSize: 1009,
+  noEmptyFiles: 1010,
+  missingContentType: 1011,
+  malformedMultipart: 1012,
+  missingMultipartBoundary: 1013,
+  unknownTransferEncoding: 1014,
+  maxFilesExceeded: 1015,
+  biggerThanMaxFileSize: 1016,
+  pluginFailed: 1017,
+  cannotCreateDir: 1018,
+};

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -97,6 +97,7 @@ export const QueryAndMutationKeys = {
   Product: ['product'],
   Images: ['images'],
   ListImages: ['ListImages'],
+  UploadImage: ['UploadImage'],
   UpdateCartTotalAmount: ['updateCartTotalAmount'],
   Login: ['login'],
   Register: ['register'],

--- a/utils/handleError.ts
+++ b/utils/handleError.ts
@@ -10,6 +10,8 @@ const POSSIBLE_ERRORS = {
   'product was not found on the server!':
     'Product was not found on the server!',
   'cart was not found on the server!': 'Cart was not found on the server!',
+  'file exists in database already': 'File exists in database already',
+  'invalid file type': 'Invalid file type',
 } as const;
 
 type KnownErrorTexts = keyof typeof POSSIBLE_ERRORS;


### PR DESCRIPTION
Add features to /pages/admin/upload-images. Now user gets toasts if something went wrong / goes right when uploading image. Add more checks in backend etc

Tasks:

- [x] Add a popup / toast when image has been successfully uploaded
- [x] Clear the image when upload has been successful
- [x] Add a Tanstack query to the upload function




Closes issue #15 